### PR TITLE
Fix oversize linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ DEPLOY_TO_GITHUB: &DEPLOY_TO_GITHUB
     - mkdir $name
     - cp target/$TARGET/release/primitive_image $name/
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      strip $name;
       zip -r $name.zip $name;
       fi
     - if [ "$TRAVIS_OS_NAME" == "osx" ]; then


### PR DESCRIPTION
Simple one-line addition to strip the binary of unneeded symbols; this reduces the executable from ~32 MB to ~1.5 MB